### PR TITLE
WI21-112_Fix_sta_bug

### DIFF
--- a/MicroPython/src/cloud/AWS_cloud.py
+++ b/MicroPython/src/cloud/AWS_cloud.py
@@ -33,7 +33,6 @@ class AWS_cloud(CloudProvider):
             logging.info(wireless_controller.sta_handler.ifconfig())
             self.configure_aws_thing()
             config.cfg.access_points = data
-            config.cfg.save()
         except Exception as e:
             logging.error("Exception caught: {}".format(e))
             config.cfg.access_points = config.DEFAULT_ACCESS_POINTS

--- a/MicroPython/src/cloud/AWS_cloud.py
+++ b/MicroPython/src/cloud/AWS_cloud.py
@@ -7,7 +7,6 @@ from os import mkdir
 
 from common import config, utils
 from communication import wirerless_connection_controller
-from controller.main_controller_event import MainControllerEvent, MainControllerEventType
 from cloud.cloud_interface import CloudProvider
 
 
@@ -23,9 +22,6 @@ class AWS_cloud(CloudProvider):
         :return: Error code (0 - OK, 1 - Error).
         """
 
-        config.cfg.access_points = data
-        config.cfg.save()
-
         logging.info("Wifi access point configuration:")
 
         for access_point in data:
@@ -33,14 +29,16 @@ class AWS_cloud(CloudProvider):
 
         wireless_controller = wirerless_connection_controller.get_wireless_connection_controller_instance()
         try:
-            utils.connect_to_wifi(wireless_controller)
+            utils.connect_to_wifi(wireless_controller, data)
             logging.info(wireless_controller.sta_handler.ifconfig())
             self.configure_aws_thing()
+            config.cfg.access_points = data
+            config.cfg.save()
         except Exception as e:
-            logging.error("Exception catched: {}".format(e))
-            event = MainControllerEvent(MainControllerEventType.ERROR_OCCURRED)
-            self.add_event(event)
-            return 1
+            logging.error("Exception caught: {}".format(e))
+            config.cfg.access_points = config.DEFAULT_ACCESS_POINTS
+            config.cfg.save()
+            machine.reset()
 
         config.cfg.ap_config_done = True
         config.cfg.save()

--- a/MicroPython/src/cloud/KAA_cloud.py
+++ b/MicroPython/src/cloud/KAA_cloud.py
@@ -64,7 +64,6 @@ class KAA_cloud(CloudProvider):
             logging.info(wireless_controller.sta_handler.ifconfig())
             self.configure_data()
             config.cfg.access_points = data
-            config.cfg.save()
         except Exception as e:
             logging.error("Exception caught: {}".format(e))
             config.cfg.access_points = config.DEFAULT_ACCESS_POINTS

--- a/MicroPython/src/common/utils.py
+++ b/MicroPython/src/common/utils.py
@@ -171,7 +171,8 @@ def get_wifi_and_cloud_handlers(sync_time: bool = False) -> (WirelessConnectionC
         except Exception:
             logging.error("Error in disconnecting WiFi controller")
 
-        logging.debug("sleep({})".format(config.cfg.data_publishing_period_in_ms))
+        logging.debug("Unable to publish data - no WIFI connection available. Retrying in {}ms".format(
+            config.cfg.data_publishing_period_in_ms))
         machine.deepsleep(config.cfg.data_publishing_period_in_ms)
 
     return wireless_controller, mqtt_communicator
@@ -192,7 +193,7 @@ def connect_to_wifi(wireless_controller: WirelessConnectionController, wifi_cred
     try:
         wireless_controller.configure_station()
     except Exception as e:
-        logging.info(e)
+        logging.info("Failed to connect to wifi {}".format(e))
         try:
             wireless_controller.disconnect_station()
         except Exception:

--- a/MicroPython/src/common/utils.py
+++ b/MicroPython/src/common/utils.py
@@ -152,11 +152,11 @@ def get_wifi_and_cloud_handlers(sync_time: bool = False) -> (WirelessConnectionC
     wireless_controller = wirerless_connection_controller.get_wireless_connection_controller_instance()
 
     try:
-        connect_to_wifi(wireless_controller, sync_time)
-        mqtt_communicator = MQTTCommunicator(cloud_provider=config.cfg.cloud_provider, 
+        connect_to_wifi(wireless_controller, config.cfg.access_points, sync_time)
+        mqtt_communicator = MQTTCommunicator(cloud_provider=config.cfg.cloud_provider,
                                              timeout=config.cfg.mqtt_timeout)
-        
-        while not wireless_controller.sta_handler.isconnected(): 
+
+        while not wireless_controller.sta_handler.isconnected():
             utime.sleep_ms(1)
 
         mqtt_communicator.connect()
@@ -171,26 +171,28 @@ def get_wifi_and_cloud_handlers(sync_time: bool = False) -> (WirelessConnectionC
         except Exception:
             logging.error("Error in disconnecting WiFi controller")
 
-        logging.debug("RESETTING BOARD")
-        machine.reset()
+        logging.debug("sleep({})".format(config.cfg.data_publishing_period_in_ms))
+        machine.deepsleep(config.cfg.data_publishing_period_in_ms)
 
     return wireless_controller, mqtt_communicator
 
 
-def connect_to_wifi(wireless_controller: WirelessConnectionController, sync_time: bool = False) -> None:
+def connect_to_wifi(wireless_controller: WirelessConnectionController, wifi_credentials: list[dict],
+                    sync_time: bool = False) -> None:
     """
     Connects ESP to wifi.
     :param wireless_controller: Wifi handler
+    :param wifi_credentials: list of ssid & password pairs
     :param sync_time: flag if time is synced.
     :return: None
     """
     logging.debug("utils.py/connect_to_wifi({})".format(sync_time))
-    wireless_controller.setup_station(access_points=config.cfg.access_points)
+    wireless_controller.setup_station(access_points=wifi_credentials)
 
     try:
         wireless_controller.configure_station()
     except Exception as e:
-        logging.info("Failed to connect to wifi {}".format(e))
+        logging.info(e)
         try:
             wireless_controller.disconnect_station()
         except Exception:

--- a/MicroPython/src/main.py
+++ b/MicroPython/src/main.py
@@ -24,9 +24,8 @@ def main():
         logging.debug("Access points saved:")
         for ap in config.cfg.access_points:
             logging.debug("SSID: {} Password: {}".format(ap["ssid"], ap["password"]))
-        if config.cfg.access_points != []:
+        if config.cfg.access_points != config.DEFAULT_ACCESS_POINTS:
             logging.debug("Access points aren't default. Try to connect")
-            pass
         else:
             logging.debug("=== Entering configuration mode ===")
 


### PR DESCRIPTION
Changes made:
- Reset configuration & hotspot if IoT Starter can't establish a connection to any AP during setup or is unexpectedly restarted during this process.
- Once IoT Starter has been successfully configured but can't connect to any AP during normal operation, go to sleep for the standard data publishing interval period given instead of endlessly restarting.